### PR TITLE
Resolve symlinks to script path correctly

### DIFF
--- a/autorecon.py
+++ b/autorecon.py
@@ -34,7 +34,7 @@ global_patterns = []
 username_wordlist = '/usr/share/seclists/Usernames/top-usernames-shortlist.txt'
 password_wordlist = '/usr/share/seclists/Passwords/darkweb2017-top100.txt'
 
-rootdir = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+rootdir = os.path.dirname(os.path.realpath(__file__))
 
 single_target = False
 only_scans_dir = False


### PR DESCRIPTION
Previously: If a symlink to autorecon.py is executed, the configuration directory is found relative to the current directory
Now: The symlink is resolved and the configuration directory is found relative to the symlink target

Explained differently: The script now takes `__file__`, looks up the real path (by resolving symlinks and/or turning the relative path into an absolute one) and takes the directory name. Bonus: It's easier to understand than the previous code and should otherwise work the same.