### PR TITLE
Added script to install tools and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ tnscmd10g
 whatweb
 wkhtmltoimage
 ```
+Some of them are part of packages with different names, and thus must be installed with those names (svwar is from the package "sipvicious" for example). A list of the packages can be found in "packages.txt". If you want to automate the installation of all these packages (not all are installed in Kali by default), use the provided install script like so:
+
+```
+$ chmod +x install-tools.sh
+$ ./install-tools.sh
+```
 
 ## Usage
 

--- a/install-tools.sh
+++ b/install-tools.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo -e "\e[1;33m [+] Updating repositiories... \e[0m"
+sudo apt -qq update &&
+echo -e "\e[1;32m [+] Repositories updated! \e[0m"
+
+echo -e "\e[1;33m [+] Installing tools from listing found in packages.txt... \e[0m"
+while read package; do
+	sudo apt -qq install $package -y
+done < packages.txt
+echo -e "\e[1;32m [+] All tools and dependencies installed! \e[0m"
+
+echo -e "\e[1;33m [+] Cleaning system... \e[0m"
+sudo apt -qq autoremove -y &&
+sudo apt -qq autoclean &&
+sudo apt -qq clean &&
+echo -e "\e[1;32m [+] Done! \e[0m"

--- a/packages.txt
+++ b/packages.txt
@@ -1,0 +1,17 @@
+curl
+enum4linux
+gobuster
+nbtscan
+nikto
+nmap
+onesixtyone
+oscanner
+smbclient
+smbmap
+smtp-user-enum
+snmp
+sslscan
+sipvicious
+tnscmd10g
+whatweb
+wkhtmltopdf


### PR DESCRIPTION
I noticed several of the tools autorecon tries to invoke are not included in Kali and that their package names do not always match the tool name. For example, `sudo apt install wkhtmltoimage` will not work, because that tool is included with the "wkhtmltopdf" package and must be installed with `sudo apt install wkhtmltopdf`. Similarly, "svwar" is from the "sipvicious" package. To save people some Googling and running a bunch of install commands, I created a file with a list of all the correct packages and a script which will install everything in the list and then clean up. The README has been updated to reflect this.

Possible related issue numbers:
#41 