### PR TITLE
Update service-scans-default.toml

### DIFF
--- a/src/autorecon/config/service-scans-default.toml
+++ b/src/autorecon/config/service-scans-default.toml
@@ -145,8 +145,8 @@ ignore-service-names = [
     [[http.manual]]
     description = '(dirsearch) Multi-threaded recursive directory/file enumeration for web servers using various wordlists:'
     commands = [
-        'dirsearch -u {scheme}://{address}:{port}/ -t 16 -r -e txt,html,php,asp,aspx,jsp -f -w /usr/share/seclists/Discovery/Web-Content/big.txt --plain-text-report="{scandir}/{protocol}_{port}_{scheme}_dirsearch_big.txt"',
-        'dirsearch -u {scheme}://{address}:{port}/ -t 16 -r -e txt,html,php,asp,aspx,jsp -f -w /usr/share/wordlists/dirbuster/directory-list-2.3-medium.txt --plain-text-report="{scandir}/{protocol}_{port}_{scheme}_dirsearch_dirbuster.txt"'
+        'dirsearch -u {scheme}://{address}:{port}/ -t 16 -r -e txt,html,php,asp,aspx,jsp -f -w /usr/share/seclists/Discovery/Web-Content/big.txt --output="{scandir}/{protocol}_{port}_{scheme}_dirsearch_big.txt" --format=plain',
+        'dirsearch -u {scheme}://{address}:{port}/ -t 16 -r -e txt,html,php,asp,aspx,jsp -f -w /usr/share/wordlists/dirbuster/directory-list-2.3-medium.txt --output="{scandir}/{protocol}_{port}_{scheme}_dirsearch_dirbuster.txt" --format=plain'
     ]
 
     [[http.manual]]


### PR DESCRIPTION
This is an update in the Dirsearch report's option syntax.