### PR TITLE
Use hydra for smtp-user-enum and try multiple methods.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN sudo apt install python3-pip -y
 RUN python3 -m pip install --user pipx
 RUN python3 -m pipx ensurepath
 RUN python3 -m pip install git+https://github.com/Tib3rius/AutoRecon.git
-RUN sudo apt install seclists curl enum4linux gobuster nbtscan nikto nmap onesixtyone oscanner smbclient smbmap smtp-user-enum snmp sslscan sipvicious tnscmd10g whatweb wkhtmltopdf -y
+RUN sudo apt install seclists curl enum4linux gobuster nbtscan nikto nmap onesixtyone oscanner smbclient smbmap snmp sslscan sipvicious tnscmd10g whatweb wkhtmltopdf -y
 RUN echo "Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/kali/.local/bin"" >> /etc/sudoers
 RUN apt-get -y autoremove && apt-get -y autoclean
 ENTRYPOINT ["autorecon"]

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ onesixtyone
 oscanner
 smbclient
 smbmap
-smtp-user-enum
 snmpwalk
 sslscan
 svwar
@@ -131,7 +130,7 @@ wkhtmltoimage
 On Kali Linux, you can ensure these are all installed using the following command:
 
 ```bash
-$ sudo apt install seclists curl enum4linux feroxbuster nbtscan nikto nmap onesixtyone oscanner smbclient smbmap smtp-user-enum snmp sslscan sipvicious tnscmd10g whatweb wkhtmltopdf
+$ sudo apt install seclists curl enum4linux feroxbuster nbtscan nikto nmap onesixtyone oscanner smbclient smbmap snmp sslscan sipvicious tnscmd10g whatweb wkhtmltopdf
 ```
 
 ## Installation

--- a/src/autorecon/config/service-scans-default.toml
+++ b/src/autorecon/config/service-scans-default.toml
@@ -488,8 +488,18 @@ service-names = [
     command = 'nmap {nmap_extra} -sV -p {port} --script="banner,(smtp* or ssl*) and not (brute or broadcast or dos or external or fuzzer)" -oN "{scandir}/{protocol}_{port}_smtp_nmap.txt" -oX "{scandir}/xml/{protocol}_{port}_smtp_nmap.xml" {address}'
 
     [[smtp.scan]]
-    name = 'smtp-user-enum'
-    command = 'smtp-user-enum -M VRFY -U "{username_wordlist}" -t {address} -p {port} 2>&1 | tee "{scandir}/{protocol}_{port}_smtp_user-enum.txt"'
+    name = 'hydra-smtp-enum-vrfy'
+    command = 'hydra smtp-enum://{address}:{port}/vrfy -L "{username_wordlist}" -o "{scandir}/{protocol}_{port}_smtp_user-enum_hydra_vrfy.txt"'
+
+    [[smtp.scan]]
+    name = 'hydra-smtp-enum-expn'
+    command = 'hydra smtp-enum://{address}:{port}/expn -L "{username_wordlist}" -o "{scandir}/{protocol}_{port}_smtp_user-enum_hydra_expn.txt"'
+
+    [[smtp.manual]]
+    description = 'Try User Enumeration using "RCPT TO". Replace <TARGET-DOMAIN> with the targets domain name.'
+    commands = [
+        'hydra smtp-enum://{address}:{port}/rcpt -L "{username_wordlist}" -o "{scandir}/{protocol}_{port}_smtp_user-enum_hydra_rcpt.txt" -p <TARGET-DOMAIN>'
+    ]
 
 [snmp]
 


### PR DESCRIPTION
smtp-user-enum is slow as it opens a new connection for each attempted username.
Hydra tries usernames until the server terminates the connection.

Additionally this removes one dependency for AutoRecon.