### PR TITLE
Add DnsRecon scans to default dns plugin

### DIFF
--- a/autorecon/default-plugins/dns.py
+++ b/autorecon/default-plugins/dns.py
@@ -1,5 +1,5 @@
 from autorecon.plugins import ServiceScan
-from autorecon.io import error, info, fformat
+from autorecon.io import error
 from shutil import which
 
 class NmapDNS(ServiceScan):
@@ -59,54 +59,53 @@ class NmapMulticastDNS(ServiceScan):
 		await service.execute('nmap {nmap_extra} -sV -p {port} --script="banner,(dns* or ssl*) and not (brute or broadcast or dos or external or fuzzer)" -oN "{scandir}/{protocol}_{port}_multicastdns_nmap.txt" -oX "{scandir}/xml/{protocol}_{port}_multicastdns_nmap.xml" {address}')
 
 
-class DnsReconDefault (ServiceScan):
-        def __init__(self):
-                super().__init__()
-                self.name = "DnsRecon Default Scan"
-                self.slug = 'dnsrecon'
-                self.priority = 0
-                self.tags = ['default', 'safe', 'dns']
+class DnsReconDefault(ServiceScan):
 
-        def configure(self):
-                self.match_service_name('^domain')
+    def __init__(self):
+        super().__init__()
+        self.name = "DnsRecon Default Scan"
+        self.slug = 'dnsrecon'
+        self.priority = 0
+        self.tags = ['default', 'safe', 'dns']
 
-        def check(self):
-                tool = 'dnsrecon'
-                if which('gobuster') is None:
-                        error('The program dnsrecon could not be found. Make sure it is installed. (On Kali, run: sudo apt install dnsrecon)')
+    def configure(self):
+        self.match_service_name('^domain')
 
-        def manual(self, service, plugin_was_run):
-                service.add_manual_command('Use dnsrecon to automatically query data from the DNS server. You must specify the target domain name.', [
-                        'dnsrecon -n {address} -d <DOMAIN-NAME> | tee {scandir}/{protocol}_{port}_dnsrecon_default_manual.txt'
-                ])
+    def check(self):
+        if which('dnsrecon') is None:
+            error('The program dnsrecon could not be found. Make sure it is installed. (On Kali, run: sudo apt install dnsrecon)')
 
-        async def run(self, service):
-                if self.get_global('domain'):
-                        await service.execute('dnsrecon -n {address} -d ' + self.get_global('domain'), outfile='{protocol}_{port}_dnsrecon_default.txt')
-                else:
-                        await service.execute('echo "Domain name was not specified in the command line options. If you know the domain name, then look in the manual commands file for the dnsrecon command."', outfile='{scandir}/{protocol}_{port}_dnsrecon_default.txt')
-                        
-class DnsReconSubdomainBruteforce (ServiceScan):
-        def __init__(self):
-                super().__init__()
-                self.name = "DnsRecon Bruteforce Subdomains"
-                self.slug = 'dnsrecon-brute'
-                self.priority = 0
-                self.tags = ['default', 'safe', 'long', 'dns']
+    def manual(self, service, plugin_was_run):
+        service.add_manual_command('Use dnsrecon to automatically query data from the DNS server. You must specify the target domain name.', [
+            'dnsrecon -n {address} -d <DOMAIN-NAME> 2>&1 | tee {scandir}/{protocol}_{port}_dnsrecon_default_manual.txt'
+        ])
 
-        def configure(self):
-                self.match_service_name('^domain')
+    async def run(self, service):
+        if self.get_global('domain'):
+            await service.execute('dnsrecon -n {address} -d ' + self.get_global('domain') + ' 2>&1', outfile='{protocol}_{port}_dnsrecon_default.txt')
+        else:
+            error('A domain name was not specified in the command line options (--global.domain). If you know the domain name, look in the _manual_commands.txt file for the dnsrecon command.')
 
-        def check(self):
-                tool = 'dnsrecon'
-                if which('gobuster') is None:
-                        error('The program dnsrecon could not be found. Make sure it is installed. (On Kali, run: sudo apt install dnsrecon)')
+class DnsReconSubdomainBruteforce(ServiceScan):
 
-        def manual(self, service, plugin_was_run):
-                domain_name = '<DOMAIN-NAME>'
-                if self.get_global('domain'):
-                    domain_name = self.get_global('domain')
-                service.add_manual_command('Use dnsrecon to bruteforce subdomains of a DNS domain.', [
-                        'dnsrecon -n {address} -d ' + domain_name + ' -D /usr/share/seclists/Discovery/DNS/subdomains-top1million-110000.txt -t brt | tee {scandir}/{protocol}_{port}_dnsrecon_subdomain_bruteforce.txt',
-                ])
+    def __init__(self):
+        super().__init__()
+        self.name = "DnsRecon Bruteforce Subdomains"
+        self.slug = 'dnsrecon-brute'
+        self.priority = 0
+        self.tags = ['default', 'safe', 'long', 'dns']
 
+    def configure(self):
+        self.match_service_name('^domain')
+
+    def check(self):
+        if which('dnsrecon') is None:
+            error('The program dnsrecon could not be found. Make sure it is installed. (On Kali, run: sudo apt install dnsrecon)')
+
+    def manual(self, service, plugin_was_run):
+        domain_name = '<DOMAIN-NAME>'
+        if self.get_global('domain'):
+            domain_name = self.get_global('domain')
+        service.add_manual_command('Use dnsrecon to bruteforce subdomains of a DNS domain.', [
+            'dnsrecon -n {address} -d ' + domain_name + ' -D /usr/share/seclists/Discovery/DNS/subdomains-top1million-110000.txt -t brt 2>&1 | tee {scandir}/{protocol}_{port}_dnsrecon_subdomain_bruteforce.txt',
+        ])

--- a/autorecon/default-plugins/dns.py
+++ b/autorecon/default-plugins/dns.py
@@ -1,4 +1,6 @@
 from autorecon.plugins import ServiceScan
+from autorecon.io import error, info, fformat
+from shutil import which
 
 class NmapDNS(ServiceScan):
 
@@ -55,3 +57,56 @@ class NmapMulticastDNS(ServiceScan):
 
 	async def run(self, service):
 		await service.execute('nmap {nmap_extra} -sV -p {port} --script="banner,(dns* or ssl*) and not (brute or broadcast or dos or external or fuzzer)" -oN "{scandir}/{protocol}_{port}_multicastdns_nmap.txt" -oX "{scandir}/xml/{protocol}_{port}_multicastdns_nmap.xml" {address}')
+
+
+class DnsReconDefault (ServiceScan):
+        def __init__(self):
+                super().__init__()
+                self.name = "DnsRecon Default Scan"
+                self.slug = 'dnsrecon'
+                self.priority = 0
+                self.tags = ['default', 'safe', 'dns']
+
+        def configure(self):
+                self.match_service_name('^domain')
+
+        def check(self):
+                tool = 'dnsrecon'
+                if which('gobuster') is None:
+                        error('The program dnsrecon could not be found. Make sure it is installed. (On Kali, run: sudo apt install dnsrecon)')
+
+        def manual(self, service, plugin_was_run):
+                service.add_manual_command('Use dnsrecon to automatically query data from the DNS server. You must specify the target domain name.', [
+                        'dnsrecon -n {address} -d <DOMAIN-NAME> | tee {scandir}/{protocol}_{port}_dnsrecon_default_manual.txt'
+                ])
+
+        async def run(self, service):
+                if self.get_global('domain'):
+                        await service.execute('dnsrecon -n {address} -d ' + self.get_global('domain'), outfile='{protocol}_{port}_dnsrecon_default.txt')
+                else:
+                        await service.execute('echo "Domain name was not specified in the command line options. If you know the domain name, then look in the manual commands file for the dnsrecon command."', outfile='{scandir}/{protocol}_{port}_dnsrecon_default.txt')
+                        
+class DnsReconSubdomainBruteforce (ServiceScan):
+        def __init__(self):
+                super().__init__()
+                self.name = "DnsRecon Bruteforce Subdomains"
+                self.slug = 'dnsrecon-brute'
+                self.priority = 0
+                self.tags = ['default', 'safe', 'long', 'dns']
+
+        def configure(self):
+                self.match_service_name('^domain')
+
+        def check(self):
+                tool = 'dnsrecon'
+                if which('gobuster') is None:
+                        error('The program dnsrecon could not be found. Make sure it is installed. (On Kali, run: sudo apt install dnsrecon)')
+
+        def manual(self, service, plugin_was_run):
+                domain_name = '<DOMAIN-NAME>'
+                if self.get_global('domain'):
+                    domain_name = self.get_global('domain')
+                service.add_manual_command('Use dnsrecon to bruteforce subdomains of a DNS domain.', [
+                        'dnsrecon -n {address} -d ' + domain_name + ' -D /usr/share/seclists/Discovery/DNS/subdomains-top1million-110000.txt -t brt | tee {scandir}/{protocol}_{port}_dnsrecon_subdomain_bruteforce.txt',
+                ])
+

--- a/autorecon/main.py
+++ b/autorecon/main.py
@@ -17,7 +17,7 @@ from autorecon.io import slugify, e, fformat, cprint, debug, info, warn, error, 
 from autorecon.plugins import Pattern, PortScan, ServiceScan, Report, AutoRecon
 from autorecon.targets import Target, Service
 
-VERSION = "2.0.4"
+VERSION = "2.0.7"
 
 if not os.path.exists(config['config_dir']):
 	shutil.rmtree(config['config_dir'], ignore_errors=True, onerror=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "autorecon"
-version = "2.0.4"
+version = "2.0.7"
 description = "A multi-threaded network reconnaissance tool which performs automated enumeration of services."
 authors = ["Tib3rius"]
 license = "GNU GPL v3"


### PR DESCRIPTION
DnsRecon is a super useful tool for querying a dns server and getting information out of it. I thought it would be nice to include it in AutoRecon's repertoire.