### PR TITLE
Fixes and New Scan feature

### DIFF
--- a/autorecon/default-plugins/http_server.py
+++ b/autorecon/default-plugins/http_server.py
@@ -79,11 +79,11 @@ class CurlRobots(ServiceScan):
 			else:
 				info('{bblue}[' + fformat('{tag}') + ']{rst} There did not appear to be a robots.txt file in the webroot (/).')
 
-class CurlKnowSecurity(ServiceScan):
+class CurlKnownSecurity(ServiceScan):
 
 	def __init__(self):
 		super().__init__()
-		self.name = "Know Security"
+		self.name = "Known Security"
 		self.tags = ['default', 'safe', 'http']
 
 	def configure(self):
@@ -147,7 +147,7 @@ class DirBuster(ServiceScan):
 				else:
 					await service.execute('dirsearch -u {http_scheme}://{address}:{port}/ -t ' + str(self.get_option('threads')) + ' -e "' + self.get_option('ext') + '" -f -q -w ' + wordlist + ' --format=plain -o "{scandir}/{protocol}_{port}_{http_scheme}_dirsearch_' + name + '.txt"')
 			elif self.get_option('tool') == 'ffuf':
-				await service.execute('ffuf -u {http_scheme}://{addressv6}:{port}/FUZZ -t ' + str(self.get_option('threads')) + ' -w ' + wordlist + ' -e "' + dot_extensions + '" -v | tee {scandir}/{protocol}_{port}_{http_scheme}_ffuf_' + name + '.txt')
+				await service.execute('ffuf -u {http_scheme}://{addressv6}:{port}/FUZZ -t ' + str(self.get_option('threads')) + ' -w ' + wordlist + ' -e "' + dot_extensions + '" -v -noninteractive | tee {scandir}/{protocol}_{port}_{http_scheme}_ffuf_' + name + '.txt')
 			elif self.get_option('tool') == 'dirb':
 				await service.execute('dirb {http_scheme}://{addressv6}:{port}/ ' + wordlist + ' -l -r -S -X ",' + dot_extensions + '" -o "{scandir}/{protocol}_{port}_{http_scheme}_dirb_' + name + '.txt"')
 

--- a/autorecon/default-plugins/smb.py
+++ b/autorecon/default-plugins/smb.py
@@ -82,7 +82,7 @@ class SMBClient(ServiceScan):
 		self.run_once(True)
 
 	async def run(self, service):
-		await service.execute('smbclient -L {address} -N 2>&1', outfile='smbclient.txt')
+		await service.execute('smbclient -L //{address} -N -I {address} 2>&1', outfile='smbclient.txt')
 
 class SMBMap(ServiceScan):
 

--- a/autorecon/default-plugins/smb.py
+++ b/autorecon/default-plugins/smb.py
@@ -82,7 +82,7 @@ class SMBClient(ServiceScan):
 		self.run_once(True)
 
 	async def run(self, service):
-		await service.execute('smbclient -L\\\\ -N -I {address} 2>&1', outfile='smbclient.txt')
+		await service.execute('smbclient -L\\\ -N {address} 2>&1', outfile='smbclient.txt')
 
 class SMBMap(ServiceScan):
 

--- a/autorecon/default-plugins/smb.py
+++ b/autorecon/default-plugins/smb.py
@@ -82,7 +82,7 @@ class SMBClient(ServiceScan):
 		self.run_once(True)
 
 	async def run(self, service):
-		await service.execute('smbclient -L\\\ -N {address} 2>&1', outfile='smbclient.txt')
+		await service.execute('smbclient -L {address} -N 2>&1', outfile='smbclient.txt')
 
 class SMBMap(ServiceScan):
 

--- a/autorecon/main.py
+++ b/autorecon/main.py
@@ -17,7 +17,7 @@ from autorecon.io import slugify, e, fformat, cprint, debug, info, warn, error, 
 from autorecon.plugins import Pattern, PortScan, ServiceScan, Report, AutoRecon
 from autorecon.targets import Target, Service
 
-VERSION = "2.0.5"
+VERSION = "2.0.6"
 
 if not os.path.exists(config['config_dir']):
 	shutil.rmtree(config['config_dir'], ignore_errors=True, onerror=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "autorecon"
-version = "2.0.5"
+version = "2.0.6"
 description = "A multi-threaded network reconnaissance tool which performs automated enumeration of services."
 authors = ["Tib3rius"]
 license = "GNU GPL v3"


### PR DESCRIPTION
Fix FFuF dirbuster scan as it as an extra parameter which prevents it from working
Fix SMBClient as the options prevent it from working.
Add new HTTP scan option for security.txt

Tested on Kali Linux and THM boxes.