### PR TITLE
Fix small bug from curl 404 output

### DIFF
--- a/autorecon/main.py
+++ b/autorecon/main.py
@@ -235,7 +235,7 @@ async def port_scan(plugin, target):
 				warn('A process was left running after port scan {bblue}' + plugin.name + ' {green}(' + plugin.slug + '){rst} against {byellow}' + target.address + '{rst} finished. Please ensure non-blocking processes are awaited before the run coroutine finishes. Awaiting now.', verbosity=2)
 				await process_dict['process'].wait()
 
-			if process_dict['process'].returncode != 0:
+			if process_dict['process'].returncode != 0 or (process_dict['cmd'].contains('curl') and process_dict['process'].returncode != 22):
 				errors = []
 				while True:
 					line = await process_dict['stderr'].readline()

--- a/autorecon/main.py
+++ b/autorecon/main.py
@@ -235,7 +235,7 @@ async def port_scan(plugin, target):
 				warn('A process was left running after port scan {bblue}' + plugin.name + ' {green}(' + plugin.slug + '){rst} against {byellow}' + target.address + '{rst} finished. Please ensure non-blocking processes are awaited before the run coroutine finishes. Awaiting now.', verbosity=2)
 				await process_dict['process'].wait()
 
-			if process_dict['process'].returncode != 0 or (process_dict['cmd'].contains('curl') and process_dict['process'].returncode != 22):
+			if process_dict['process'].returncode != 0:
 				errors = []
 				while True:
 					line = await process_dict['stderr'].readline()
@@ -323,7 +323,7 @@ async def service_scan(plugin, service):
 				warn('A process was left running after service scan {bblue}' + plugin.name + ' {green}(' + tag + '){rst} against {byellow}' + service.target.address + '{rst} finished. Please ensure non-blocking processes are awaited before the run coroutine finishes. Awaiting now.', verbosity=2)
 				await process_dict['process'].wait()
 
-			if process_dict['process'].returncode != 0:
+			if process_dict['process'].returncode != 0 and not (process_dict['cmd'].startswith('curl') and process_dict['process'].returncode == 22):
 				errors = []
 				while True:
 					line = await process_dict['stderr'].readline()


### PR DESCRIPTION
This PR fixes a small bug from when `curl` receives an `HTTP 404` from the web server and the error code is non-zero (in this case `22`). This handles that case in the if statement. There may other error codes that `curl` throws, HTTP-wise, that you may want to catch in the future as well but I didn't run into them.