### PR TITLE
Enumeration of vhost should ignore TLS/SSL certificate errors

### DIFF
--- a/autorecon/default-plugins/http_server.py
+++ b/autorecon/default-plugins/http_server.py
@@ -223,7 +223,7 @@ class VirtualHost(ServiceScan):
 			for wordlist in self.get_option('wordlist'):
 				name = os.path.splitext(os.path.basename(wordlist))[0]
 				for hostname in hostnames:
-					await service.execute('gobuster vhost -u {http_scheme}://' + hostname + ':{port}/ -t ' + str(self.get_option('threads')) + ' -w ' + wordlist + ' -r -o "{scandir}/{protocol}_{port}_{http_scheme}_' + hostname + '_vhosts_' + name + '.txt"')
+					await service.execute('gobuster vhost -k -u {http_scheme}://' + hostname + ':{port}/ -t ' + str(self.get_option('threads')) + ' -w ' + wordlist + ' -r -o "{scandir}/{protocol}_{port}_{http_scheme}_' + hostname + '_vhosts_' + name + '.txt"')
 		else:
 			service.info('The target was not a hostname, nor was a hostname provided as an option. Skipping virtual host enumeration.')
 

--- a/autorecon/main.py
+++ b/autorecon/main.py
@@ -17,7 +17,7 @@ from autorecon.io import slugify, e, fformat, cprint, debug, info, warn, error, 
 from autorecon.plugins import Pattern, PortScan, ServiceScan, Report, AutoRecon
 from autorecon.targets import Target, Service
 
-VERSION = "2.0.14"
+VERSION = "2.0.15"
 
 if not os.path.exists(config['config_dir']):
 	shutil.rmtree(config['config_dir'], ignore_errors=True, onerror=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "autorecon"
-version = "2.0.14"
+version = "2.0.15"
 description = "A multi-threaded network reconnaissance tool which performs automated enumeration of services."
 authors = ["Tib3rius"]
 license = "GNU GPL v3"


### PR DESCRIPTION
The tool `gobuster` that is used for vhost enumeration fails if the enumerated host presents a TLS/SSL certificate that `gobuster` cannot validate but `AutoRecon` probably wants `gobuster` to ignore the invalid certificate and continue to enumerate.
Adding the `-k` option to the `gobuster` call so that `gobuster` ignores the invalid certificate