### PR TITLE
Added enum4linux-ng choice

### DIFF
--- a/autorecon/default-plugins/enum4linux.py
+++ b/autorecon/default-plugins/enum4linux.py
@@ -1,4 +1,5 @@
 from autorecon.plugins import ServiceScan
+from shutil import which
 
 class Enum4Linux(ServiceScan):
 
@@ -8,11 +9,24 @@ class Enum4Linux(ServiceScan):
 		self.tags = ['default', 'safe', 'active-directory']
 
 	def configure(self):
+		self.add_choice_option('tool', default='enum4linux', choices=['enum4linux', 'enum4linux-ng'], help='The tool to use for doing Windows and Samba enumeration. Default: %(default)s')
 		self.match_service_name(['^ldap', '^smb', '^microsoft\-ds', '^netbios'])
 		self.match_port('tcp', [139, 389, 445])
 		self.match_port('udp', 137)
 		self.run_once(True)
-
+	
+	def check(self):
+		tool = self.get_option('tool')
+		if tool == 'enum4linux':
+			if which('enum4linux') is None:
+				self.error('The enum4linux program could not be found. Make sure it is installed. (On Kali, run: sudo apt install enum4linux)')
+		elif tool == 'enum4linux-ng':
+			if which('enum4linux-ng') is None:
+				self.error('The enum4linux-ng program could not be found. Make sure it is installed. (On Kali, run: sudo apt install enum4linux-ng)')
+		
 	async def run(self, service):
 		if service.target.ipversion == 'IPv4':
-			await service.execute('enum4linux -a -M -l -d {address} 2>&1', outfile='enum4linux.txt')
+			if self.get_option('tool') == 'enum4linux':
+				await service.execute('enum4linux -a -M -l -d {address} 2>&1', outfile='enum4linux.txt')
+			elif self.get_option('tool') == 'enum4linux-ng':
+				await service.execute('enum4linux-ng -A -L -d {address} 2>&1', outfile='enum4linux-ng.txt')

--- a/autorecon/default-plugins/enum4linux.py
+++ b/autorecon/default-plugins/enum4linux.py
@@ -9,24 +9,25 @@ class Enum4Linux(ServiceScan):
 		self.tags = ['default', 'safe', 'active-directory']
 
 	def configure(self):
-		self.add_choice_option('tool', default='enum4linux', choices=['enum4linux', 'enum4linux-ng'], help='The tool to use for doing Windows and Samba enumeration. Default: %(default)s')
+		self.add_choice_option('tool', default=('enum4linux-ng' if which('enum4linux-ng') else 'enum4linux'), choices=['enum4linux-ng', 'enum4linux'], help='The tool to use for doing Windows and Samba enumeration. Default: %(default)s')
 		self.match_service_name(['^ldap', '^smb', '^microsoft\-ds', '^netbios'])
 		self.match_port('tcp', [139, 389, 445])
 		self.match_port('udp', 137)
 		self.run_once(True)
-	
+
 	def check(self):
 		tool = self.get_option('tool')
-		if tool == 'enum4linux':
-			if which('enum4linux') is None:
-				self.error('The enum4linux program could not be found. Make sure it is installed. (On Kali, run: sudo apt install enum4linux)')
-		elif tool == 'enum4linux-ng':
-			if which('enum4linux-ng') is None:
-				self.error('The enum4linux-ng program could not be found. Make sure it is installed. (On Kali, run: sudo apt install enum4linux-ng)')
-		
+		if tool == 'enum4linux' and which('enum4linux') is None:
+			self.error('The enum4linux program could not be found. Make sure it is installed. (On Kali, run: sudo apt install enum4linux)')
+			return False
+		elif tool == 'enum4linux-ng' and which('enum4linux-ng') is None:
+			self.error('The enum4linux-ng program could not be found. Make sure it is installed. (https://github.com/cddmp/enum4linux-ng)')
+			return False
+
 	async def run(self, service):
 		if service.target.ipversion == 'IPv4':
-			if self.get_option('tool') == 'enum4linux':
-				await service.execute('enum4linux -a -M -l -d {address} 2>&1', outfile='enum4linux.txt')
-			elif self.get_option('tool') == 'enum4linux-ng':
-				await service.execute('enum4linux-ng -A -L -d {address} 2>&1', outfile='enum4linux-ng.txt')
+			if self.tool is not None:
+				if self.tool == 'enum4linux':
+					await service.execute('enum4linux -a -M -l -d {address} 2>&1', outfile='enum4linux.txt')
+				elif self.tool == 'enum4linux-ng':
+					await service.execute('enum4linux-ng -A -d -v {address} 2>&1', outfile='enum4linux-ng.txt')


### PR DESCRIPTION
Good morning,

In this PR, I added the choice to use `enum4linux-ng` (https://github.com/cddmp/enum4linux-ng) instead of `enum4linux` using the option `--enum4linux.tool`, here is an example, new behaviour using `enum4linux-ng`:
```console
autorecon -p 139 --enum4linux.tool 'enum4linux-ng' TARGET
```

Old behaviour using `enum4linux`:
```console
autorecon -p 139 TARGET
```

Regards.