### PR TITLE
nuclei plugin added.

### DIFF
--- a/autorecon/default-plugins/nuclei.py
+++ b/autorecon/default-plugins/nuclei.py
@@ -1,0 +1,20 @@
+from autorecon.plugins import ServiceScan
+
+class Nikto(ServiceScan):
+
+	def __init__(self):
+		super().__init__()
+		self.name = 'nuclei'
+		self.tags = ['default', 'safe', 'long', 'http']
+
+	def configure(self):
+		self.match_service_name('^http')
+		self.match_service_name('^nacn_http$', negative_match=True)
+
+	async def run(self, service):
+		if service.target.ipversion == 'IPv4':
+			await service.execute('nuclei -target {http_scheme}://{address}:{port} -scan-all-ips -automatic-scan 2>&1 | tee "{scandir}/{protocol}_{port}_{http_scheme}_nuclei.txt"')
+
+	def manual(self, service, plugin_was_run):
+		if service.target.ipversion == 'IPv4' and not plugin_was_run:
+			service.add_manual_command('(nuclei) powerful & highly configurable web server enumeration tool from projectdiscovery.io:', 'nuclei -target {http_scheme}://{address}:{port} -scan-all-ips -automatic-scan 2>&1 | tee "{scandir}/{protocol}_{port}_{http_scheme}_nuclei.txt"')


### PR DESCRIPTION
This is a plugin template for the Nuclei tool.

`-scan-all-ips -automatic-scan` added for coverage and to perform targeted vuln scans respectively.

The `-automatic-scan` uses Wappalyzer to detect the technology in use and only scans for that specific stuff making it considerably less noisy than usual.