### PR TITLE
Fix smbmap recursive flag case

### DIFF
--- a/autorecon/default-plugins/smbmap.py
+++ b/autorecon/default-plugins/smbmap.py
@@ -14,7 +14,7 @@ class SMBMap(ServiceScan):
 		if service.target.ipversion == 'IPv4':
 			await service.execute('smbmap -H {address} -P {port} 2>&1', outfile='smbmap-share-permissions.txt')
 			await service.execute('smbmap -u null -p "" -H {address} -P {port} 2>&1', outfile='smbmap-share-permissions.txt')
-			await service.execute('smbmap -H {address} -P {port} -R 2>&1', outfile='smbmap-list-contents.txt')
-			await service.execute('smbmap -u null -p "" -H {address} -P {port} -R 2>&1', outfile='smbmap-list-contents.txt')
+			await service.execute('smbmap -H {address} -P {port} -r 2>&1', outfile='smbmap-list-contents.txt')
+			await service.execute('smbmap -u null -p "" -H {address} -P {port} -r 2>&1', outfile='smbmap-list-contents.txt')
 			await service.execute('smbmap -H {address} -P {port} -x "ipconfig /all" 2>&1', outfile='smbmap-execute-command.txt')
 			await service.execute('smbmap -u null -p "" -H {address} -P {port} -x "ipconfig /all" 2>&1', outfile='smbmap-execute-command.txt')


### PR DESCRIPTION
The capitalization case of smbmap recursive option is not lowercase and therefor fails prior to this change.

>        man smbmap
>        -r [PATH]
>               Recursively list dirs, and files (no share\path lists ALL shares), ex. ’C$\Finance’

