### PR TITLE
Add nuclei plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN wget -q -O - https://archive.kali.org/archive-key.asc  | apt-key add -
 RUN echo "deb http://http.kali.org/kali kali-rolling main contrib non-free" >> /etc/apt/sources.list
 RUN apt-get update
 
-RUN apt-get install -y python3 python3-pip git seclists curl dnsrecon enum4linux feroxbuster gobuster impacket-scripts nbtscan nikto nmap onesixtyone oscanner redis-tools smbclient smbmap snmp sslscan sipvicious tnscmd10g whatweb wkhtmltopdf
+RUN apt-get install -y python3 python3-pip git seclists curl dnsrecon enum4linux feroxbuster gobuster impacket-scripts nbtscan nikto nmap nuclei onesixtyone oscanner redis-tools smbclient smbmap snmp sslscan sipvicious tnscmd10g whatweb wkhtmltopdf
 RUN python3 -m pip install git+https://github.com/Tib3rius/AutoRecon.git
 
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ impacket-scripts
 nbtscan
 nikto
 nmap
+nuclei
 onesixtyone
 oscanner
 redis-tools
@@ -88,7 +89,7 @@ wkhtmltopdf
 On Kali Linux, you can ensure these are all installed using the following commands:
 
 ```bash
-sudo apt install seclists curl dnsrecon enum4linux feroxbuster gobuster impacket-scripts nbtscan nikto nmap onesixtyone oscanner redis-tools smbclient smbmap snmp sslscan sipvicious tnscmd10g whatweb wkhtmltopdf
+sudo apt install seclists curl dnsrecon enum4linux feroxbuster gobuster impacket-scripts nbtscan nikto nmap nuclei onesixtyone oscanner redis-tools smbclient smbmap snmp sslscan sipvicious tnscmd10g whatweb wkhtmltopdf
 ```
 
 ### Installation Method #1: pipx (Recommended)

--- a/autorecon/default-plugins/nuclei.py
+++ b/autorecon/default-plugins/nuclei.py
@@ -1,0 +1,36 @@
+from autorecon.plugins import ServiceScan
+from shutil import which
+
+
+class Nuclei(ServiceScan):
+    def __init__(self):
+        super().__init__()
+        self.name = "nuclei"
+        self.tags = ["default", "safe", "long"]
+
+        self.cmd = 'nuclei -disable-update-check -no-color -target {address}:{port} -scan-all-ips -o "{scandir}/{protocol}_{port}_nuclei.txt"'
+
+    def configure(self):
+        self.match_all_service_names(True)
+        self.add_pattern(
+            r"(.*\[(critical|high)\].*)",
+            description="Nuclei {match2} finding: {match1}",
+        )
+
+    def check(self):
+        if which("nuclei") is None:
+            self.error(
+                "The program nuclei could not be found. Make sure it is installed. (On Kali, run: sudo apt install nuclei)"
+            )
+            return False
+
+    async def run(self, service):
+        if service.target.ipversion == "IPv4":
+            await service.execute(self.cmd)
+
+    def manual(self, service, plugin_was_run):
+        if service.target.ipversion == "IPv4" and not plugin_was_run:
+            service.add_manual_command(
+                f"({self.name}) Fast and customizable vulnerability scanner based on simple YAML based DSL:",
+                self.cmd,
+            )


### PR DESCRIPTION
Thanks for the really useful tool. I've added [nuclei](https://github.com/projectdiscovery/nuclei) as plugin.

I've seen #200, but I went with different approach regarding the conditions for it to run - for each TCP port. There are nuclei templates for network discovery and CVEs (for example [here](https://github.com/projectdiscovery/nuclei-templates/tree/main/network)). I've also addressed the issues you mentioned there.