### PR TITLE
Replace deprecated appdirs with platformdirs

### DIFF
--- a/autorecon/config.py
+++ b/autorecon/config.py
@@ -1,7 +1,7 @@
-import appdirs, os
+import platformdirs, os
 
-config_dir = appdirs.user_config_dir('AutoRecon')
-data_dir = appdirs.user_data_dir('AutoRecon')
+config_dir = platformdirs.user_config_dir('AutoRecon')
+data_dir = platformdirs.user_data_dir('AutoRecon')
 
 configurable_keys = [
 	'ports',

--- a/autorecon/main.py
+++ b/autorecon/main.py
@@ -4,7 +4,7 @@ import argparse, asyncio, importlib.util, inspect, ipaddress, math, os, re, sele
 from datetime import datetime
 
 try:
-	import appdirs, colorama, impacket, psutil, requests, toml, unidecode
+	import colorama, impacket, platformdirs, psutil, requests, toml, unidecode
 	from colorama import Fore, Style
 except ModuleNotFoundError:
 	print('One or more required modules was not installed. Please run or re-run: ' + ('sudo ' if os.getuid() == 0 else '') + 'python3 -m pip install -r requirements.txt')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-appdirs = "^1.4.4"
+platformdirs = "^4.3.6"
 colorama = "^0.4.5"
 impacket = "^0.10.0"
 psutil = "^5.9.4"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-appdirs>=1.4.4
 colorama>=0.4.5
 impacket>=0.10.0
+platformdirs>=4.3.6
 psutil>=5.9.4
 requests>=2.28.1
 toml>=0.10.2


### PR DESCRIPTION
Hello

The module appdirs has been officially deprecated by upstream and has now been removed from Debian too.
It should be replaced with the current active fork platformdirs:

https://github.com/ActiveState/appdirs
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1060427

Thanks